### PR TITLE
Fix: Run build on PHP 7.3 instead of PHP 7.2

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
+          - "7.3"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
This pull requests

- [x] runs the build on PHP 7.3 instead of PHP 7.2